### PR TITLE
Update MiSeq_runs_basespace.sh

### DIFF
--- a/MiSeq_runs_basespace.sh
+++ b/MiSeq_runs_basespace.sh
@@ -79,6 +79,9 @@ do
         
         icav2 projects enter Testing \
           2>> $icav2_log.err | tee -a $ica2_log.log
+        
+        wait
+        
         icav2 projectdata upload /Volumes/IDGenomics_NAS/WGS_Serotyping/$run_name/Sequencing_reads/Raw /$run_name/ \
           2>> $icav2_log.err | tee -a $ica2_log.log
         


### PR DESCRIPTION
The first test run of this script failed. Looking at the log it looks like the command for icav2 on line 80 was not able to finish.  I am not sure but I think adding in this wait command should fix this issue.  