### PR TITLE
Update MiSeq_runs_basespace.sh to prevent ICA from crashing it.

### DIFF
--- a/MiSeq_runs_basespace.sh
+++ b/MiSeq_runs_basespace.sh
@@ -79,7 +79,7 @@ do
         
         icav2 projects enter Testing \
           2>> $icav2_log.err | tee -a $ica2_log.log
-        icav2 projectdata upload /Volumes/IDGenomics_NAS/WGS_Serotyping/$run_name/Sequencing_reads/Raw /$run_name/ \
+        echo y | icav2 projectdata upload /Volumes/IDGenomics_NAS/WGS_Serotyping/$run_name/Sequencing_reads/Raw /$run_name/ \
           2>> $icav2_log.err | tee -a $ica2_log.log
         
         wait


### PR DESCRIPTION
Added line that prevents script from crashing from ICA folder that is already in existence.