### PR TITLE
John more scripts

### DIFF
--- a/accession_for_clarity_backup.py
+++ b/accession_for_clarity_backup.py
@@ -81,8 +81,8 @@ tmp = tmp.drop(columns= ['observations'])
 clarity = clarity.append(tmp, ignore_index=True)
 
 #tmp = tmp.drop(columns= ['ORF1ab Ct','N gene Ct','S gene Ct'])
-tmp['UDF/Provider Code'] = 'UPHL'
-clarity = clarity.append(tmp, ignore_index=True)
+#tmp['UDF/Provider Code'] = 'UPHL'
+#clarity = clarity.append(tmp, ignore_index=True)
 
 tmp=ppanther.rename(columns={'sampleNumber':'Sample/Name',
                       'collectionDate':'UDF/Sample Collection DateTime',

--- a/accession_for_clarity_backup.py
+++ b/accession_for_clarity_backup.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+# Written in Python 3.11.2. Tested on Python 3.7.11,3.8.8, 3.9.13, 3.10.8
+
+# Packages Needed pandas, openpyxl, xlrd
+# Install with: pip3 install pandas openpyxl xlrd
+
+"""
+This is a modified version of accession_for_clarity.py, which strips out the search and retrivial of 
+samples tested at UPHL and found in the shared drives work books. This portion of the script often fails
+for unkown reasons and these samples are the least the we process we get a majority from IHC,ARUP, and U of U;
+because of this I made this backup for that the majority of samples could make it into Clarity.
+
+ONLY USE IF MAIN SCRIPT IS NOT WORKING AND WARN THE LAB OF THIS.
+"""
+
+import pandas as pd
+import os
+import sys
+import numpy as np
+import glob
+import re
+from datetime import datetime, timedelta
+
+print("Running!!!")
+
+
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action='ignore', category=UserWarning)
+### USAGE ### python accession_for_clarity.py "path/to/files/fromclarity" "path/to/files/fromclarity.etc"
+# Must be log into or mount these servers smb://172.16.109.9 smb://168.180.220.43. Must include files, project samplesheets, from Clarity for all COVIDSEQ projects
+# DO NOT MAKE DUPLICATES IN CLARITY!!! PLEASE READ README.md and proceed with caution. 
+
+
+path_to_project_lists=[]
+for i in range(len(sys.argv)-1):
+    path_to_project_lists.append(str(sys.argv[i+1]))
+    print('Import %d' % i)
+
+atog=[]
+for i in ['A','B','C','D','E','F','G','H']:
+
+     for j in range(12):
+        atog.append('%s%s' % (i,(j+1)))
+
+# Import All_ncovid*.csv
+#ip address smb://172.16.109.9 smb://168.180.220.43
+ncovid=pd.read_csv('/Volumes/LABWARE/Shared_Files/Mirth/COVID_data_import/ncovOverview.csv',usecols=['submitterId','sampleNumber','collectionDate','receivedDate','result','customer'], encoding = "ISO-8859-1", low_memory=False)
+print("Read ncovid!")
+# Import NGS_Covid_*.csv
+NGS_Covid=pd.read_csv('/Volumes/LABWARE/Shared_Files/Mirth/COVID_data_import/NGS_Covidtest.csv',usecols=['observations','customer','submitterId','sampleNumber','collectionDate','receivedDate','PlateName','PlateWell'], encoding = "ISO-8859-1", low_memory=False)
+print("Read NGS_Covid")
+NGS_Covid['receivedDate']=NGS_Covid['receivedDate'].fillna(NGS_Covid['collectionDate'])
+# Clean up
+end = datetime.now().date()
+plot_end=end
+plot_start=end-timedelta(days=30)
+NGS_Covid['receivedDate']= pd.to_datetime(NGS_Covid['receivedDate']).dt.date
+NGS_Covid=NGS_Covid[(NGS_Covid['receivedDate'] > plot_start) & (NGS_Covid['receivedDate'] < plot_end)]
+NGS_Covid=NGS_Covid.drop(columns=['receivedDate'])
+
+#Get Panther Tubes
+end = datetime.now().date()
+plot_end=end
+plot_start=end-timedelta(days=30)
+ncovid['receivedDate']= pd.to_datetime(ncovid['receivedDate'], errors='coerce').dt.date
+panther=ncovid[(ncovid['receivedDate'] > plot_start) & (ncovid['receivedDate'] < plot_end)]
+panther=panther.drop(columns=['receivedDate'])
+ppanther = panther[panther['result']== 'SARS-COV-2 Detected']
+
+# Create DF to merge into
+clarity= pd.DataFrame(columns = ['Sample/Name', 'Container/Type', 'Container/Name', 'Sample/Well Location',
+                             'UDF/External Sample ID',
+                             'UDF/Sample Collection DateTime','UDF/Test Requested','UDF/Test Selected','UDF/Provider Code'])
+# Merge NGS_Covid into clarity
+tmp = NGS_Covid.rename(columns={'customer': 'UDF/Provider Code', 'sampleNumber': 'Sample/Name',
+                               'submitterId':'UDF/External Sample ID', 'collectionDate':'UDF/Sample Collection DateTime',
+                               'PlateName':'Container/Name','PlateWell':'Sample/Well Location'})
+tmp = tmp.drop(columns= ['observations'])
+clarity = clarity.append(tmp, ignore_index=True)
+
+#tmp = tmp.drop(columns= ['ORF1ab Ct','N gene Ct','S gene Ct'])
+tmp['UDF/Provider Code'] = 'UPHL'
+clarity = clarity.append(tmp, ignore_index=True)
+
+tmp=ppanther.rename(columns={'sampleNumber':'Sample/Name',
+                      'collectionDate':'UDF/Sample Collection DateTime',
+                     'customer':'UDF/Provider Code'})
+tmp = tmp.drop(columns= ['submitterId','result'])
+tmp['Sample/Name'] = tmp['Sample/Name'].astype(int)
+clarity = clarity.append(tmp, ignore_index=True)
+
+
+# Filter Out Samples Already in Clarity
+i=0
+for j in path_to_project_lists:
+    columns=list(pd.read_excel('%s' % j, skiprows=2,nrows=0).columns)
+    columns={v: k for v, k in enumerate(columns)}
+    if i == 0:
+        in_c_tmp=pd.read_excel('%s' % j, skiprows=5, header=None)
+        in_c_tmp=in_c_tmp.rename(columns=columns)
+        in_c_tmp.drop(in_c_tmp.tail(1).index,inplace=True)
+        in_c=in_c_tmp
+    if i >0:
+        in_c_tmp=pd.read_excel('%s' % j, skiprows=5, header=None)
+        in_c_tmp=in_c_tmp.rename(columns=columns)
+        in_c_tmp.drop(in_c.tail(1).index,inplace=True, errors='ignore')
+        in_c_tmp['Sample/Name'] = pd.to_numeric(in_c_tmp['Sample/Name'], errors='coerce')
+        in_c=in_c.append(in_c_tmp, ignore_index=True)
+    i=+ 1
+    print("Imported: %s" % j)
+
+samples = in_c['Sample/Name'].tolist()
+
+
+clarity = clarity.drop(list(clarity[clarity['Sample/Name'].isin(samples)].index))
+
+
+clarity['UDF/Test Requested']= 'COVIDSeq'
+clarity['UDF/Test Selected']= 'COVIDSeq'
+for index,row in clarity.iterrows():
+    if  not pd.isnull(row['Container/Name']):
+        row['Container/Type'] = '96 well plate'
+# Fix the Well Locations to match Clarity
+for index, row in clarity.iterrows():
+    if not pd.isnull(row['Sample/Well Location']):
+        tmp=list(row['Sample/Well Location'])
+        tmp.insert(1, ':')
+        if tmp[2] == '0':
+            del tmp[2]
+        tmp=''.join(tmp)
+        row['Sample/Well Location'] = tmp
+
+clarity = clarity.replace(np.nan, '', regex=True)
+hold=clarity.values.tolist()
+hold.insert( 0, ["<TABLE HEADER>"])
+hold.insert( 1, ["Sample/Name", "Container/Type", "Container/Name", "Sample/Well Location", "UDF/External Sample ID","UDF/Sample Collection DateTime", "UDF/Test Requested","UDF/Test Selected", "UDF/Provider Code"])
+hold.insert( 2, ["</TABLE HEADER>"])
+hold.insert( 3, ["<SAMPLE ENTRIES>"])
+hold.append(["</SAMPLE ENTRIES>"])
+
+with open('accession_for_clarity%s.csv' % datetime.now().strftime("%Y_%m_%d"), 'w+') as f:
+    for i in hold:
+        for j in range(len(i)):
+            if j == len(i)-1:
+                f.write('%s' %i[j])
+                continue
+            f.write('%s,' %i[j])
+        f.write('\n')
+
+print("A csv file has been created for Clarity at: %s/accession_for_clarity%s.csv" % (os.getcwd(),datetime.now().strftime("%Y_%m_%d")))

--- a/clarity_ids.py
+++ b/clarity_ids.py
@@ -14,6 +14,8 @@ You also need to provide one of three flags:
 
 The output of this script is a csv file into the directory the script was ran in named clarity_ids_output.csv.
 OR use flag '--output' to provide full path and name of file
+
+Users must have an account in Clarity that has the System Adminastrator Role.
 """
 
 import argparse

--- a/clarity_ids.py
+++ b/clarity_ids.py
@@ -1,0 +1,88 @@
+import argparse
+import xml.etree.ElementTree as ET
+import requests
+from requests.auth import HTTPBasicAuth
+import re
+import pandas as pd
+
+parser = argparse.ArgumentParser(description="A script that accepts user, password, and data source options.")
+    
+# Required arguments
+parser.add_argument("--user", help="User name")
+parser.add_argument("--password", help="User's password")
+
+# Either list or file must be provided
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument("--list", help="Specify a list of samples you need ids for. 123,124,125")
+group.add_argument("--file", help="Specify a file that has a sample name for each line of file")
+group.add_argument("--all", action="store_true", help="Creates csv of all sampels")
+
+args = parser.parse_args()
+
+def flatten(l):
+    return [item for sublist in l for item in sublist]
+
+udfs=['ARLN ID','CDC ID','GCWGS ID','GISP ID','PNUSA Number']
+
+if args.all:
+    sample_lims_ids = []
+
+    xml=(requests.get("https://uphl-ngs.claritylims.com/api/v2/samples", 
+            auth=HTTPBasicAuth(args.user, args.password)).content).decode("utf-8")
+
+    sample_lims_ids.append(re.findall(r'limsid="([^"]+)"', xml))
+
+    index=500
+    while index > 0:
+        xml=(requests.get("https://uphl-ngs.claritylims.com/api/v2/samples?start-index=%s" % index, 
+            auth=HTTPBasicAuth(args.user, args.password)).content).decode("utf-8")
+        index+=500
+        if len(xml) < 300:
+            index=0
+        sample_lims_ids.append(re.findall(r'limsid="([^"]+)"', xml))
+
+    sample_lims_ids=flatten(sample_lims_ids)
+
+if args.list:
+    sample_lims_ids = args.list.split(',')
+
+if args.file:
+    sample_lims_ids = []
+
+    with open(args.fil, 'r') as file:
+        for line in file:
+            sample_lims_ids.append(line.strip())
+
+limsids = {}
+for j in sample_lims_ids:
+    print(j)
+    xml=(requests.get("https://uphl-ngs.claritylims.com/api/v2/samples?name=%s" % j, 
+        auth=HTTPBasicAuth(args.user, args.password)).content).decode("utf-8")
+    # Parse the XML data
+    limsids[j]=(re.findall(r'limsid="([^"]+)"', xml))
+
+ids_df=[]
+
+for j in limsids.keys():
+    xml=(requests.get("https://uphl-ngs.claritylims.com/api/v2/samples/%s" % limsids[j][0], 
+        auth=HTTPBasicAuth(args.user, args.password)).content).decode("utf-8")
+    # Parse the XML data
+    root = ET.fromstring(xml)
+                                            
+    namespace_map = {
+                    'udf': 'http://genologics.com/ri/userdefined',
+                    'ri': 'http://genologics.com/ri',
+                    'file': 'http://genologics.com/ri/file',
+                    'smp': 'http://genologics.com/ri/sample'}
+
+    # Find the udf:field element with name="Species"
+    ids=[]
+    for i in udfs:
+        species_element = root.find('.//udf:field[@name="%s"]'% i, namespaces=namespace_map)
+        try:
+            ids.append(species_element.text)
+        except:
+            ids.append("")
+    ids_df.append([j]+ids)
+
+pd.DataFrame(ids_df, columns = ['Sample_ID']+udfs).to_csv('clarity_ids_output.csv', index=False)

--- a/clarity_ids.py
+++ b/clarity_ids.py
@@ -26,8 +26,8 @@ import pandas as pd
 parser = argparse.ArgumentParser(description="A script that accepts user, password, and data source options.")
     
 # Required arguments
-parser.add_argument("--user", help="User name")
-parser.add_argument("--password", help="User's password")
+parser.add_argument("--user", required=True, help="User name")
+parser.add_argument("--password", required=True, help="User's password")
 parser.add_argument("--output", help="Creates csv of all sampels")
 
 # Either list or file must be provided
@@ -42,6 +42,14 @@ def flatten(l):
     return [item for sublist in l for item in sublist]
 
 udfs=['ARLN ID','CDC ID','GCWGS ID','GISP ID','PNUSA Number']
+
+# Check User Name and Password
+xml = (requests.get("https://uphl-ngs.claritylims.com/api/v2/samples/%s" % 'WAG357A292', 
+        auth=HTTPBasicAuth(args.user, args.password)).content).decode("utf-8")
+check=(re.findall(r'<message>(.*?)</message>', xml))
+
+if check == ['Unauthorized']:
+    sys.exit('User name or password is unauthorized. Please check username and password!')
 
 if args.all:
     sample_lims_ids = []

--- a/rename_clarity_objects.py
+++ b/rename_clarity_objects.py
@@ -17,14 +17,15 @@ from lxml import etree
 import requests
 from requests.auth import HTTPBasicAuth
 import re
+import sys
 
 
 parser = argparse.ArgumentParser(description="A script that updates Clarity Derived Samples and Container names")
     
 # Required arguments
-parser.add_argument("--user", help="User name")
-parser.add_argument("--password", help="User's password")
-parser.add_argument("--new_name", help="What you want to rename the sample too")
+parser.add_argument("--user", required=True, help="User name")
+parser.add_argument("--password", required=True, help="User's password")
+parser.add_argument("--new_name", required=True, help="What you want to rename the sample too")
 
 # Either list or file must be provided
 group = parser.add_mutually_exclusive_group(required=True)
@@ -34,6 +35,15 @@ group.add_argument("--container", help="limsid of container")
 args = parser.parse_args()
 
 headers = {'Content-Type': 'application/xml'}
+
+
+# Check User Name and Password
+xml = (requests.get("https://uphl-ngs.claritylims.com/api/v2/samples/%s" % 'WAG357A292', 
+        auth=HTTPBasicAuth(args.user, args.password)).content).decode("utf-8")
+check=(re.findall(r'<message>(.*?)</message>', xml))
+
+if check == ['Unauthorized']:
+    sys.exit('User name or password is unauthorized. Please check username and password!')
 
 if args.container:
     info=requests.get(

--- a/rename_clarity_objects.py
+++ b/rename_clarity_objects.py
@@ -8,6 +8,8 @@ Usage:
 This script is to be used to rename artifacts and containers in Clarity. You need to provide your Clarity 
 username and password, the lims id of the sample you want to change, weather its a artifact or container,
 and the new_name.
+
+Users must have an account in Clarity that has the System Adminastrator Role.
 """
 
 

--- a/rename_clarity_objects.py
+++ b/rename_clarity_objects.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+"""
+Author: John Arnn
+Release Date: 10/12/2023
+
+Usage:
+This script is to be used to rename artifacts and containers in Clarity. You need to provide your Clarity 
+username and password, the lims id of the sample you want to change, weather its a artifact or container,
+and the new_name.
+"""
+
+
+import argparse
+import xml.etree.ElementTree as ET
+from lxml import etree
+import requests
+from requests.auth import HTTPBasicAuth
+import re
+
+
+parser = argparse.ArgumentParser(description="A script that updates Clarity Derived Samples and Container names")
+    
+# Required arguments
+parser.add_argument("--user", help="User name")
+parser.add_argument("--password", help="User's password")
+parser.add_argument("--new_name", help="What you want to rename the sample too")
+
+# Either list or file must be provided
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument("--artifact", help="limsid of derived sample or artifact")
+group.add_argument("--container", help="limsid of container")
+
+args = parser.parse_args()
+
+headers = {'Content-Type': 'application/xml'}
+
+if args.container:
+    info=requests.get(
+      "https://uphl-ngs.claritylims.com/api/v2/containers/%s" % args.container,
+      auth=HTTPBasicAuth(args.user, args.password)
+    ).content
+
+    doc = etree.fromstring(info)
+    for e in doc.iterfind("name"):
+        e.text = args.new_name
+    xml=etree.tostring(doc).decode("utf-8")
+    print("Verify that one of the names is the intended name of the plate you want to change:")
+    print(set(info.decode("utf-8").split()).symmetric_difference(set(xml.split()))-{'<?xml', 'version="1.0"', 'standalone="yes"?>', 'encoding="UTF-8"'})
+
+    proceed = input("Continue: y/n? ")
+
+    if proceed == 'y':
+        requests.put(
+        "https://uphl-ngs.claritylims.com/api/v2/containers/%s" % args.container, data=xml, headers=headers,
+        auth=HTTPBasicAuth(args.user, args.password)
+        ).content
+
+if args.artifact:
+    info=requests.get(
+      "https://uphl-ngs.claritylims.com/api/v2/artifacts/%s" % args.artifact,
+      auth=HTTPBasicAuth(args.user, args.password)
+    ).content
+
+    doc = etree.fromstring(info)
+    for e in doc.iterfind("name"):
+        e.text = args.new_name
+    xml=etree.tostring(doc).decode("utf-8")
+    print("Verify that one of the names is the intended name of the plate you want to change:")
+    print(set(info.decode("utf-8").split()).symmetric_difference(set(xml.split()))-{'<?xml', 'version="1.0"', 'standalone="yes"?>', 'encoding="UTF-8"'})
+
+    proceed = input("Continue: y/n? ")
+
+    if proceed == 'y':
+        requests.put(
+        "https://uphl-ngs.claritylims.com/api/v2/artifacts/%s" % args.artifact, data=xml, headers=headers,
+        auth=HTTPBasicAuth(args.user, args.password)
+        ).content
+


### PR DESCRIPTION
I want to add a few more scripts so that we are not so reliant on my clarity dashboard which requires SSH access. These new scripts allow you to use your own Clarity credentials to get ids, and update plates/artifact names. I also added the backup to accession Clarity samples; it is simpler and should work more easily than the current one but will miss samples tested here at UPHL. That usually less than a dozen a week so it not the perfect; but will at least keep things moving in the lab.

Please make sure that these scripts work for you. You may need to install new libraries for them to work. 