### PR TITLE
Dripping Rock R script to be trigger by cron job

### DIFF
--- a/Dripping_Rock_R.R
+++ b/Dripping_Rock_R.R
@@ -1,0 +1,17 @@
+#!/usr/bin/env Rscript
+# Author: OLP/12/2023
+# Usage: Trigger the Dripping_Rock workflow using linux/crontab.
+# last modified on 01/09/2024 (MM/DD/YYYY)
+
+  library("easypackages");libraries("data.table","readr","dplyr")
+  sup <- suppressPackageStartupMessages
+      
+  setwd("/Volumes/IDGenomics_NAS/COVID/daily_metadata/") 
+  dir.create(as.character.Date(Sys.Date()))
+  setwd(paste("/Volumes/IDGenomics_NAS/COVID/daily_metadata/",as.character.Date(Sys.Date()),sep="/"))
+  
+  print("RDripping_Rock wf")
+  
+  nextflow_script <- "/home/Bioinformatics/Dripping_Rock"
+  system(paste("nextflow run", nextflow_script))
+

--- a/README.md
+++ b/README.md
@@ -106,3 +106,13 @@ This script will enter ICA's Testing Project, upload nanopore and illumina reads
 EXAMPLE:
 bash long_read_seq/Unicycler_ICA.sh UT-GXB02179-230317 sample_sheet.csv
 ```
+## Dripping_Rock_R.R
+This R script is just to trigger the Dripping_Rock wf using the Linux/crontab.
+It can also be used to trigger the Driping_Rock wf manually from any point as: Rscript / . . . ./Dripping_Rock_R.R
+
+
+
+
+
+
+


### PR DESCRIPTION
Adding an R script that can be used to trigger the Dripping_Rock wf using the Linux/crontab. It can also be used to trigger the Driping_Rock wf manually from any point as indicated in the README