### PR TITLE
initial df scripts

### DIFF
--- a/aws_samplesheet_df_create.py
+++ b/aws_samplesheet_df_create.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+"""
+Author: Erin Young
+Released: 2024-07-11
+Version: 0.0.1
+Description:
+    This script should create a sample sheet for aws usage for donut falls as well as
+    copy all files to a destination for upload.
+
+EXAMPLE:
+    python3 aws_samplesheet_df_create.py -r UT-M70330-240131 -s SampleSheet.csv -d reads
+"""
+
+
+import pandas as pd
+import os
+import sys
+import argparse
+import logging
+from pathlib import Path
+
+
+def concat_files():
+    print("hwatever")
+
+def illumina_files():
+    print("whatever")
+
+def upload_sample_sheet_instructions(run_name, directory):
+    """
+
+    Instruction for uploading the sample sheet
+    (holding place for actual uploading)
+
+    Args:
+        run_name (str): run directory to upload to
+        directory (str): where the sample sheet is located
+
+    """
+    logging.info("To get sample sheet to S3 bucket:")
+    logging.info(f"cd {directory} && aws s3 cp --profile 155221691104_dhhs-uphl-biongs-dev --region us-west-2 aws_sample_sheet.csv s3://dhhs-uphl-omics-inputs-dev/{run_name}/aws_sample_sheet.csv")
+
+
+def upload_reads_instructions(run_name, directory):
+    """
+
+    Instruction for uploading fastq files.
+    (holding place for actual uploading)
+
+    Args:
+        run_name (str): run directory to upload to
+        directory (str): where the files are located
+
+    """
+
+    logging.info("To get reads to S3 bucket:")
+    logging.info(f"cd {directory} &&  ls *fastq.gz | parallel aws s3 cp --profile 155221691104_dhhs-uphl-biongs-dev --region us-west-2 {{}} s3://dhhs-uphl-omics-inputs-dev/{run_name}/{{}}")
+
+
+def read_gridion_sample_sheet(samplesheet):
+    print(samplesheet)
+
+    df = pd.read_table(samplesheet)
+
+    return df
+
+def df_sample_sheet(run_name, samplesheet, directory):
+    """
+
+    Takes fastq file names and adds predicted paths for aws.
+
+    Args:
+        run_name (str): directory destination in aws (most commonly the run name)
+        samplesheet (str): sample sheet used to generate the fastq files
+        directory (str): directory that fastq files are located in
+
+    """
+
+    # S3 input directory
+    final_dir=f"s3://dhhs-uphl-omics-inputs-dev/{run_name}/"
+
+    # turn MiSeq sample sheet into pandas df
+    df = read_gridion_sample_sheet(samplesheet)
+
+    # file location for aws
+    sample_files = []
+
+    # get fastq file for each sample in GridIon sample sheet
+    for index, row in df.iterrows():
+        sample_name = row['Sample_Name']
+        reads = concat_files(sample_name, directory)
+        # sometimes there are no reads
+        if reads:
+            sample_files.append({'sample': sample_name, 'fastq': final_dir + reads[0].name, 'fastq_1': final_dir + reads[0].name, 'fastq_2': final_dir + reads[1].name})
+        else:
+            logging.debug(f"No fastq files were found for {sample_name}")
+
+    # creating the final dataframe
+    sample_file_df = pd.DataFrame(sample_files, columns=['sample', 'fastq_1', 'fastq_2'])
+    sample_file_df = sample_file_df.sort_values(by='sample')
+    sample_file_df.to_csv(f"{directory}/aws_sample_sheet.csv", index=False)
+
+    logging.info("DataFrame saved to aws_sample_sheet.csv.")
+    upload_sample_sheet_instructions(run_name, directory)
+    upload_reads_instructions(run_name, directory)
+
+
+def main():
+    """
+
+    Creates an AWS-friendly sample sheet.
+
+    Args:
+        args (argparse.Namespace): Parsed command-line arguments.
+    
+    """
+
+    logging.basicConfig(level=logging.INFO) 
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-r', '--run', required = True, type = str, help = 'Run name (i.e. UT-GXB04505-240621)')
+    parser.add_argument('-s', '--samplesheet', required = True, type = str, help = 'sample sheet')
+    parser.add_argument('-f', '--fastq_pass', required = True, type = str, help = 'fastq_pass directory with barcoded fastq files')
+    parser.add_argument('-o', '--out', required=False, type=str, help='directory where files are copied to for upload')
+    args = parser.parse_args()
+
+    if not os.path.exists(args.samplesheet):
+        logging.fatal(f"Sample sheet {args.samplesheet} does not exist!")
+        sys.exit()
+
+    if not os.path.exists(args.fastq_pass):
+        logging.fatal(f"Directory {args.dir} does not exist!")
+        sys.exit()
+
+    df_sample_sheet(args.run, args.samplesheet, args.fastq_pass, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/monitor_ngs.py
+++ b/monitor_ngs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+"""
+Author: Erin Young
+Released: 2024-07-15
+Version: 0.0.1
+
+Description:
+Checks if all GridIon runs in /Volumes/NGS/Output/GridION 
+have been synced with /Volumes/BioNGS_1
+
+EXAMPLE:
+python3 monitor_ngs.py
+"""
+
+import logging 
+import glob
+import shutil
+import os
+
+
+def new_gridion():
+    """
+    Sync directories containing specific files from the source to the destination.
+
+    This function searches for files matching the pattern 
+    '/Volumes/NGS/Output/GridION/*/*/*/sequencing_summary*.txt'. It then extracts
+    the run name for syncing.
+
+    Returns:
+    run (str): The run name used to construct the source and destination paths.
+    """
+
+    file_pattern = "/Volumes/NGS/Output/GridION/*/*/*/sequencing_summary*.txt"
+
+    files = glob.glob(file_pattern)
+
+    if not files:
+        logging.warning("No new files found.")
+        return
+    
+    for file in files:
+        run = os.path.dirname(file).split('/')[5]
+        if not os.path.exists(f"/Volumes/BioNGS_1/{run}"):
+            logging.info(f"New run found!: {run}")
+            return run
+
+
+def sync_directories(run):
+    """
+    Sync directories containing specific files from the source to the destination.
+
+    This function searches for files matching the pattern 
+    '/Volumes/NGS/Output/GridION/{run}/*', excluding any files with "fail" in the 
+    filename. It then syncs the directories containing these files to the 
+    destination '/Volumes/BioNGS_1/{run}' if they haven't been synced already.
+
+    Parameters:
+    run (str): The run name used to construct the source and destination paths.
+
+    Returns:
+    None
+    """
+    source_pattern = f"/Volumes/NGS/Output/GridION/{run}/"
+    destination_base = f"/Volumes/BioNGS_1/{run}"
+
+    # Find files matching the pattern, exclude "fail"
+    files = glob.glob(source_pattern)
+
+    # Get the directories containing the matched files
+    directories = {os.path.dirname(file) for file in files}
+
+    for directory in directories:
+        # Determine the corresponding destination directory
+        relative_path = os.path.relpath(directory, f"/Volumes/NGS/Output/GridION/{run}")
+        destination_dir = os.path.join(destination_base, relative_path)
+
+        # Sync the directory if it hasn't been synced already
+        if not os.path.exists(destination_dir):
+            logging.info(f"Syncing {directory} to {destination_dir}")
+            shutil.copytree(directory, destination_dir)
+        else:
+            logging.info(f"{destination_dir} already exists, skipping.")
+
+
+def main():
+    """
+    Checks if run is finished and syncs to new destination.
+    """
+
+    logging.basicConfig(level=logging.INFO) 
+
+    run = new_gridion()
+    sync_directories(run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@jwarnn , I mentioned last week that I was going to try and set something up for Donut Falls in a similar way to Grandeur.

THIS IS HOW FAR I'VE GOTTEN. I know that it currently doesn't work.

It's also as far as I'm going to go for now. You are more than welcome to tackle this challenge. I think I may give this some additional attention in October-ish. Maybe.

`monitor_ngs.py` is meant to look for new GridIon runs and copy over the files to /Volumes/BioNGS_1. Some of these will be runs for Donut Falls, some are for @poojasgupta 's projects (esp. with TaxTriage). Python's tree function, however, either takes forever or freezes, so I don't really recommend this script. 

This is what I've been doing to copy files over once I know a run is done.
```bash
run=UT-P2S01293-240711
rsync -rvh  /Volumes/NGS/Output/GridION/${run} /Volumes/BioNGS_1/ --exclude *fail*
```

I'm sticking with rsync for now.


A nanopore sequencing run is complete (generally) when the `sequencing_summary_*_*.txt` is created. Generated fastq files are not named after any user supplied id. Instead, they are divided by barcode. Each barcode _should_ have multiple fastq files that have to be combined together for further analysis/processing into one per sample.

I like to name these combined files into 'sample.fastq.gz', where sample is the lims id. 

Then we get to the hard part: For Donut Falls, we have to find the corresponding Illumina files for each sample - which are in a variety of locations. 

This is how I've been doing it in bash: https://github.com/UPHL-BioNGS/Donut_Falls/blob/main/bin/uphl_sample_sheet.sh , and my initial attempts at doing this in python (not working and incomplete) are found in `aws_samplesheet_df_create.py`.