### PR TITLE
Checks fastq file size for sample sheet

### DIFF
--- a/aws_samplesheet_grandeur_create.py
+++ b/aws_samplesheet_grandeur_create.py
@@ -41,7 +41,13 @@ def find_files(sample_name, directory):
     if len(files) >=2:
         # Return the first two files, and there should only be two matches
         logging.debug(f"The two files found: {files}")
-        return files[:2]
+
+        # setting the minimum filesize (5 MB in bytes_
+        min_size = 5 * 1024 * 1024
+        if files[0].stat().st_size > min_size and files[1].stat().st_size > min_size:
+            return files[:2]
+        else:
+            logging.debug(f"Both fastq files were not over 5MB!")
     else:
         logging.debug(f"Two files not found: {files}")
 


### PR DESCRIPTION
I am thinking poor-quality samples might be the cause of Grandeur's issues.

From the looks of things, there were three samples less than 1.5MB for the three runs that failed on AWS HealthOmics. We've never had a sample pass QC with files less than 10MB.

Therefore,
- samples with at least 1 file < 5MB won't pass QC
- might cause Grandeur to fail on AWS HealthOmics

So I vote we just skip them for the analysis.

This PR institutes the size check to make sure both fastq files are > 5MB.